### PR TITLE
fix user_send_packet and user_receive_packet signatures

### DIFF
--- a/content/developer/hooks.md
+++ b/content/developer/hooks.md
@@ -229,8 +229,8 @@ corresponding hooks parameters is described below.
 * unset_presence_hook(User, Server, Resource, Status) -> ok
 * user_available_hook(JID) -> ok
 * user_ping_timeout(JID) -> ok
-* user_receive_packet(JID, From, To, Packet) -> ok
-* user_send_packet(C2SState, JID, JID, Packet) -> Packet
+* user_receive_packet(Packet, C2SState, JID, From, To) -> Packet
+* user_send_packet(Packet, C2SState, From, To) -> Packet
 * vcard_set(User, Server, VCARD) -> ok
 * webadmin_menu_host(Acc, Host, Lang) -> []
 * webadmin_menu_hostnode(Acc, Host, Node, Lang) -> []


### PR DESCRIPTION
http://docs.ejabberd.im/developer/hooks/
```
user_send_packet(C2SState, JID, JID, Packet) -> Packet
```

I believe that's wrong. Isn't it:
`(Packet, C2SState, From, To) -> Packet` ?

----------
same goes for:
```
user_receive_packet(JID, From, To, Packet) -> ok
```

I believe it should be
`(Packet, C2SState, JID, From, To) -> Packet`
