### PR TITLE
Update configuration.md

### DIFF
--- a/content/admin/configuration.md
+++ b/content/admin/configuration.md
@@ -1303,7 +1303,7 @@ following syntax:
 	    acl:
 	      admin:
 	        - user:
-	          "yozhik": "example.org"
+	            "yozhik": "example.org"
 	        - user: "peter@example.org"
 
 **`server: Server`**:   Matches any JID from server `Server`. Example:


### PR DESCRIPTION
Fix indentation of `acl` -> `admin` -> `user` -> `yozhik`.

Before the change the resulting yaml layout looked like this:

```yaml
acl:
  admin:
  - {user: null, yozhik: example.org}
  - {user: peter@example.org}
```

After:

```yaml
acl:
  admin:
  - user: {yozhik: example.org}
  - {user: peter@example.org}

```