### PR TITLE
update destroy_room command

### DIFF
--- a/content/admin/ejabberdctl/muc-admin.md
+++ b/content/admin/ejabberdctl/muc-admin.md
@@ -54,7 +54,7 @@ ejabberdctl create_room room_name muc_service xmpp_domain
 Destroy a MUC chat room.
 
 ~~~ bash
-ejabberdctl destroy_room room_name muc_service xmpp_domain
+ejabberdctl destroy_room room_name muc_service
 ~~~
 
 ## Create multiple rooms from file


### PR DESCRIPTION
Enter the original command at the terminal, the error is as follows:
```
Error: the command "destroy_room" requires 1 less argument.

  Command Name: destroy_room

  Arguments: name::binary
             service::binary
             
  Returns: res::rescode

  Tags:  muc_room

  Description:  Destroy a MUC room

Error: the command "destroy_room" requires 1 less argument.
```