### PR TITLE
Local S2S can't be natively blocked

### DIFF
--- a/content/admin/configuration.md
+++ b/content/admin/configuration.md
@@ -589,7 +589,10 @@ ejabberd configuration file (outside `listen`):
 **`outgoing_s2s_timeout: Timeout`**:   The timeout in seconds for outgoing S2S connection attempts.
 
 **`s2s_access: Access`**:   The policy for incoming and outgoing s2s connections to other XMPP
-	servers. The default value is `all`.
+	servers. The default value is `all`. You can disable connections to other servers (federation)
+	here by setting it to `none`, but this will not block other locally hosted servers as, for performance
+	reasons, they are connected internally and not via the s2s module. To block even those you might
+	need to use an additional module like [this one](https://gist.github.com/zinid/2525b45610422838c87b88f2847f9bfe).
 
 **`s2s_dns_timeout: Timeout`**:   The timeout in seconds for DNS resolving. The default value is `10`.
 


### PR DESCRIPTION
Ref: https://process-one.net/logs/ejabberd@conference.process-one.net/2019/05/22.html#12:26:00.834059