### PR TITLE
Fix MQTT tables on upgrade instructions

### DIFF
--- a/content/admin/upgrade/from_18.12_to_19.02.md
+++ b/content/admin/upgrade/from_18.12_to_19.02.md
@@ -106,6 +106,7 @@ If you want to use new MQTT feature, you need to create a table:
 ```sql
 CREATE TABLE mqtt_pub (
     username varchar(191) NOT NULL,
+    server_host varchar(191) NOT NULL,
     resource varchar(191) NOT NULL,
     topic text NOT NULL,
     qos tinyint NOT NULL,
@@ -116,7 +117,7 @@ CREATE TABLE mqtt_pub (
     correlation_data blob NOT NULL,
     user_properties blob NOT NULL,
     expiry int unsigned NOT NULL,
-    UNIQUE KEY i_mqtt_topic (topic(191))
+    UNIQUE KEY i_mqtt_topic_server (topic(191))
 );
 ```
 
@@ -264,6 +265,7 @@ If you want to use new MQTT feature, you need to create a table:
 ```sql
 CREATE TABLE mqtt_pub (
     username text NOT NULL,
+    server_host text NOT NULL,
     resource text NOT NULL,
     topic text NOT NULL,
     qos smallint NOT NULL,
@@ -276,5 +278,5 @@ CREATE TABLE mqtt_pub (
     expiry bigint NOT NULL
 );
 
-CREATE UNIQUE INDEX i_mqtt_topic ON mqtt_pub (topic);
+CREATE UNIQUE INDEX i_mqtt_topic_server ON mqtt_pub (topic);
 ```

--- a/content/admin/upgrade/from_18.12_to_19.02.md
+++ b/content/admin/upgrade/from_18.12_to_19.02.md
@@ -184,6 +184,7 @@ If you want to use new MQTT feature, you need to create a table:
 ```sql
 CREATE TABLE mqtt_pub (
     username text NOT NULL,
+    server_host text NOT NULL,
     resource text NOT NULL,
     topic text NOT NULL,
     qos smallint NOT NULL,
@@ -196,7 +197,7 @@ CREATE TABLE mqtt_pub (
     expiry bigint NOT NULL
 );
 
-CREATE UNIQUE INDEX i_mqtt_topic ON mqtt_pub (topic);
+CREATE UNIQUE INDEX i_mqtt_topic_server ON mqtt_pub (topic, server_host);
 ```
 
 ### SQLite

--- a/content/admin/upgrade/from_18.12_to_19.02.md
+++ b/content/admin/upgrade/from_18.12_to_19.02.md
@@ -26,7 +26,7 @@ modules:
 
 ## Database
 
-If you want to use lastest MIX (XEP-0369) with an SQL backend then
+If you want to use latest MIX (XEP-0369) with an SQL backend then
 you have to create new tables.
 
 If you have issues using PEP and MySQL, you should update your schema.
@@ -101,7 +101,9 @@ CREATE UNIQUE INDEX i_mix_pam ON mix_pam (username(191), channel(191), service(1
 CREATE INDEX i_mix_pam_u ON mix_pam (username(191));
 ```
 
-If you want to use new MQTT feature, you need to create a table:
+If you want to use new MQTT feature, you need to create a table.
+
+If you're using the new schema (`new_sql_schema`):
 
 ```sql
 CREATE TABLE mqtt_pub (
@@ -118,6 +120,25 @@ CREATE TABLE mqtt_pub (
     user_properties blob NOT NULL,
     expiry int unsigned NOT NULL,
     UNIQUE KEY i_mqtt_topic_server (topic(191))
+);
+```
+
+If you're using the old schema:
+
+```sql
+CREATE TABLE mqtt_pub (
+    username varchar(191) NOT NULL,
+    resource varchar(191) NOT NULL,
+    topic text NOT NULL,
+    qos tinyint NOT NULL,
+    payload blob NOT NULL,
+    payload_format tinyint NOT NULL,
+    content_type text NOT NULL,
+    response_topic text NOT NULL,
+    correlation_data blob NOT NULL,
+    user_properties blob NOT NULL,
+    expiry int unsigned NOT NULL,
+    UNIQUE KEY i_mqtt_topic (topic(191))
 );
 ```
 
@@ -180,7 +201,9 @@ CREATE UNIQUE INDEX i_mix_pam ON mix_pam (username, channel, service);
 CREATE INDEX i_mix_pam_us ON mix_pam (username);
 ```
 
-If you want to use new MQTT feature, you need to create a table:
+If you want to use new MQTT feature, you need to create a table.
+
+If you're using the new schema (`new_sql_schema`):
 
 ```sql
 CREATE TABLE mqtt_pub (
@@ -199,6 +222,26 @@ CREATE TABLE mqtt_pub (
 );
 
 CREATE UNIQUE INDEX i_mqtt_topic_server ON mqtt_pub (topic, server_host);
+```
+
+If you're using the old schema:
+
+```sql
+CREATE TABLE mqtt_pub (
+    username text NOT NULL,
+    resource text NOT NULL,
+    topic text NOT NULL,
+    qos smallint NOT NULL,
+    payload bytea NOT NULL,
+    payload_format smallint NOT NULL,
+    content_type text NOT NULL,
+    response_topic text NOT NULL,
+    correlation_data bytea NOT NULL,
+    user_properties bytea NOT NULL,
+    expiry bigint NOT NULL
+);
+
+CREATE UNIQUE INDEX i_mqtt_topic ON mqtt_pub (topic, server_host);
 ```
 
 ### SQLite
@@ -260,7 +303,9 @@ CREATE UNIQUE INDEX i_mix_pam ON mix_pam (username, channel, service);
 CREATE INDEX i_mix_pam_us ON mix_pam (username);
 ```
 
-If you want to use new MQTT feature, you need to create a table:
+If you want to use new MQTT feature, you need to create a table.
+
+If you're using the new schema (`new_sql_schema`):
 
 ```sql
 CREATE TABLE mqtt_pub (
@@ -279,4 +324,24 @@ CREATE TABLE mqtt_pub (
 );
 
 CREATE UNIQUE INDEX i_mqtt_topic_server ON mqtt_pub (topic);
+```
+
+If you're using the old schema:
+
+```sql
+CREATE TABLE mqtt_pub (
+    username text NOT NULL,
+    resource text NOT NULL,
+    topic text NOT NULL,
+    qos smallint NOT NULL,
+    payload blob NOT NULL,
+    payload_format smallint NOT NULL,
+    content_type text NOT NULL,
+    response_topic text NOT NULL,
+    correlation_data blob NOT NULL,
+    user_properties blob NOT NULL,
+    expiry bigint NOT NULL
+);
+
+CREATE UNIQUE INDEX i_mqtt_topic ON mqtt_pub (topic);
 ```


### PR DESCRIPTION
The tables specified here are only for the old sql schemas, and ejabberd (19.05) refuses to boot if you use them, have `new_sql_schema` as `true` and `mod_mqtt` module is enabled.

This PR fixes that by including the right variants of the tables per schema:

https://github.com/processone/ejabberd/blob/7511da0f266e61fa12c640bd418606baca4c78ed/sql/pg.new.sql#L629-L644

https://github.com/processone/ejabberd/blob/7511da0f266e61fa12c640bd418606baca4c78ed/sql/lite.new.sql#L467-L483

https://github.com/processone/ejabberd/blob/7511da0f266e61fa12c640bd418606baca4c78ed/sql/mysql.new.sql#L484-L498