### PR TITLE
Document 'allow_unencrypted_sasl2' option

### DIFF
--- a/content/admin/configuration/listen-options.md
+++ b/content/admin/configuration/listen-options.md
@@ -11,6 +11,15 @@ modules:
 
 This option defines access to the port. The default value is `all`.
 
+## allow_unencrypted_sasl2
+
+*true | false*
+
+As per [`XEP-0388`](https://xmpp.org/extensions/xep-0388.html#security),
+ejabberd rejects SASL2 negotiations over non-TLS connections by default. Setting
+this option to `true` allows SASL2 over plaintext connections, which may be
+useful in case TLS is terminated by some proxy in front of ejabberd.
+
 ## backlog
 
 *Value*

--- a/content/admin/configuration/listen.md
+++ b/content/admin/configuration/listen.md
@@ -71,6 +71,7 @@ Handles c2s connections.
 
 General listen options supported:
 [access](listen-options.md#access),
+[allow_unencrypted_sasl2](listen-options.md#allow_unencrypted_sasl2),
 [cafile](listen-options.md#cafile),
 [ciphers](listen-options.md#ciphers),
 [dhfile](listen-options.md#dhfile),


### PR DESCRIPTION
As per [`XEP-0388`](https://xmpp.org/extensions/xep-0388.html#security), ejabberd rejects SASL2 negotiations over non-TLS connections by default. Setting the new listener option `allow_unencrypted_sasl2: true` allows SASL2 over plaintext connections, which may be useful in case TLS is terminated by some proxy in front of ejabberd.